### PR TITLE
feat: Add difficulty setting (Easy/Medium/Hard)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -952,6 +953,7 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -993,6 +995,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1108,6 +1111,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -1297,6 +1301,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2220,6 +2225,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2281,6 +2287,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2519,6 +2526,7 @@
       "integrity": "sha512-eSiiRJmovt8qDJkGyZuLnbxAOAdie6NCmmd0NkTC0RJI9duiSBTfr8X2mBYJOUFzxQa2USaHmL99J9uMxkjCyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.92.0",
         "fdir": "^6.5.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,12 +7,24 @@ const MemoryGame = () => {
   const [moves, setMoves] = useState(0);
   const [gameStarted, setGameStarted] = useState(false);
   const [gameWon, setGameWon] = useState(false);
+  const [difficulty, setDifficulty] = useState('medium');
 
-  // Card emojis for the game
-  const cardSymbols = ['🚀', '🛸', '⭐', '🌙', '🪐', '☄️', '🌟', '🌌'];
+  // All available card emojis
+  const allCardSymbols = ['🚀', '🛸', '⭐', '🌙', '🪐', '☄️', '🌟', '🌌', '🔥', '💎', '🎯', '🎨'];
+
+  // Difficulty configurations
+  const difficultyConfig = {
+    easy: { pairs: 4, columns: 4, label: 'Easy' },
+    medium: { pairs: 8, columns: 4, label: 'Medium' },
+    hard: { pairs: 12, columns: 6, label: 'Hard' }
+  };
+
+  // Get card symbols based on difficulty
+  const getCardSymbols = () => allCardSymbols.slice(0, difficultyConfig[difficulty].pairs);
 
   // Initialize game
   const initializeGame = () => {
+    const cardSymbols = getCardSymbols();
     const shuffledCards = [...cardSymbols, ...cardSymbols]
       .sort(() => Math.random() - 0.5)
       .map((symbol, index) => ({
@@ -32,6 +44,7 @@ const MemoryGame = () => {
 
   // Handle card click
   const handleCardClick = (index) => {
+    const cardSymbols = getCardSymbols();
     if (!gameStarted || gameWon) return;
     if (flippedIndices.length === 2) return;
     if (flippedIndices.includes(index)) return;
@@ -122,7 +135,7 @@ const MemoryGame = () => {
           fontWeight: 'bold'
         }}>
           <div>Moves: {moves}</div>
-          <div>Matches: {matchedPairs.length}/{cardSymbols.length}</div>
+          <div>Matches: {matchedPairs.length}/{difficultyConfig[difficulty].pairs}</div>
         </div>
       )}
 
@@ -130,7 +143,7 @@ const MemoryGame = () => {
       {gameStarted ? (
         <div style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(4, 1fr)',
+          gridTemplateColumns: `repeat(${difficultyConfig[difficulty].columns}, 1fr)`,
           gap: '15px',
           padding: '20px',
           background: 'rgba(255, 255, 255, 0.1)',
@@ -177,6 +190,44 @@ const MemoryGame = () => {
         <div style={{
           textAlign: 'center'
         }}>
+          {/* Difficulty Selector */}
+          <div style={{
+            marginBottom: '30px'
+          }}>
+            <p style={{
+              color: 'white',
+              fontSize: '20px',
+              marginBottom: '15px',
+              fontWeight: 'bold'
+            }}>
+              Select Difficulty
+            </p>
+            <div style={{
+              display: 'flex',
+              gap: '15px',
+              justifyContent: 'center'
+            }}>
+              {Object.entries(difficultyConfig).map(([key, config]) => (
+                <button
+                  key={key}
+                  onClick={() => setDifficulty(key)}
+                  style={{
+                    padding: '12px 24px',
+                    fontSize: '16px',
+                    background: difficulty === key ? 'white' : 'rgba(255, 255, 255, 0.2)',
+                    border: '2px solid white',
+                    borderRadius: '25px',
+                    cursor: 'pointer',
+                    fontWeight: 'bold',
+                    color: difficulty === key ? '#667eea' : 'white',
+                    transition: 'all 0.3s ease'
+                  }}
+                >
+                  {config.label} ({config.pairs} pairs)
+                </button>
+              ))}
+            </div>
+          </div>
           <button
             onClick={initializeGame}
             style={{


### PR DESCRIPTION
## Summary

Adds a difficulty setting that lets players choose between three levels before starting the game:

| Difficulty | Pairs | Cards | Grid |
|------------|-------|-------|------|
| Easy | 4 | 8 | 4×2 |
| Medium | 8 | 16 | 4×4 |
| Hard | 12 | 24 | 6×4 |

## Changes

- Added `difficulty` state with `easy`, `medium`, and `hard` options
- Created difficulty selector UI on the start screen with toggle buttons  
- Dynamic grid layout based on selected difficulty (4 or 6 columns)
- Extended emoji pool to 12 symbols to support Hard mode
- Stats display now reflects the selected difficulty

## Screenshot

The difficulty selector appears on the start screen before the game begins.

---

**Author:** Mux AI Agent  
**Email:** mux@coder.com  
**Note:** This PR was created by an AI Agent (Mux/Claude).