### PR TITLE
feat: add 60-second countdown timer with lose detection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 const MemoryGame = () => {
   const [cards, setCards] = useState([]);
@@ -7,12 +7,25 @@ const MemoryGame = () => {
   const [moves, setMoves] = useState(0);
   const [gameStarted, setGameStarted] = useState(false);
   const [gameWon, setGameWon] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(60);
+  const [gameLost, setGameLost] = useState(false);
+  const timerRef = useRef(null);
 
   // Card emojis for the game
   const cardSymbols = ['🚀', '🛸', '⭐', '🌙', '🪐', '☄️', '🌟', '🌌'];
 
+  // Clear the countdown interval.
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
   // Initialize game
   const initializeGame = () => {
+    clearTimer();
+
     const shuffledCards = [...cardSymbols, ...cardSymbols]
       .sort(() => Math.random() - 0.5)
       .map((symbol, index) => ({
@@ -28,11 +41,43 @@ const MemoryGame = () => {
     setMoves(0);
     setGameStarted(true);
     setGameWon(false);
+    setGameLost(false);
+    setTimeLeft(60);
+  };
+
+  // Countdown timer effect.
+  useEffect(() => {
+    if (gameStarted && !gameWon && !gameLost) {
+      timerRef.current = setInterval(() => {
+        setTimeLeft((prev) => {
+          if (prev <= 1) {
+            clearTimer();
+            setGameLost(true);
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }
+
+    return () => clearTimer();
+  }, [gameStarted, gameWon, gameLost]);
+
+  // Return to start screen after dismissing the lose modal.
+  const handleLoseDismiss = () => {
+    clearTimer();
+    setGameStarted(false);
+    setGameLost(false);
+    setTimeLeft(60);
+    setCards([]);
+    setFlippedIndices([]);
+    setMatchedPairs([]);
+    setMoves(0);
   };
 
   // Handle card click
   const handleCardClick = (index) => {
-    if (!gameStarted || gameWon) return;
+    if (!gameStarted || gameWon || gameLost) return;
     if (flippedIndices.length === 2) return;
     if (flippedIndices.includes(index)) return;
     if (matchedPairs.includes(cards[index].symbol)) return;
@@ -72,6 +117,9 @@ const MemoryGame = () => {
     document.body.style.padding = '0';
     document.body.style.overflow = 'auto';
   }, []);
+
+  // Determine the timer display color based on remaining time.
+  const timerColor = timeLeft <= 10 ? '#ff4444' : 'white';
 
   return (
     <div style={{
@@ -123,6 +171,9 @@ const MemoryGame = () => {
         }}>
           <div>Moves: {moves}</div>
           <div>Matches: {matchedPairs.length}/{cardSymbols.length}</div>
+          <div style={{ color: timerColor }}>
+            Time: {timeLeft}s
+          </div>
         </div>
       )}
 
@@ -291,6 +342,68 @@ const MemoryGame = () => {
               }}
             >
               Play Again
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Lose Modal */}
+      {gameLost && (
+        <div style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          background: 'rgba(0,0,0,0.8)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 1000
+        }}>
+          <div style={{
+            background: 'white',
+            padding: '40px',
+            borderRadius: '20px',
+            textAlign: 'center',
+            boxShadow: '0 10px 40px rgba(0,0,0,0.3)'
+          }}>
+            <h2 style={{
+              fontSize: '48px',
+              margin: '0 0 20px 0',
+              color: '#e74c3c'
+            }}>
+              ⏰ Time's Up! ⏰
+            </h2>
+            <p style={{
+              fontSize: '24px',
+              margin: '0 0 30px 0',
+              color: '#333'
+            }}>
+              You did not complete the game in time.
+            </p>
+            <button
+              onClick={handleLoseDismiss}
+              style={{
+                padding: '15px 40px',
+                fontSize: '20px',
+                background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                border: 'none',
+                borderRadius: '50px',
+                cursor: 'pointer',
+                fontWeight: 'bold',
+                color: 'white',
+                boxShadow: '0 4px 15px rgba(0,0,0,0.2)',
+                transition: 'all 0.3s ease'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.transform = 'scale(1.05)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.transform = 'scale(1)';
+              }}
+            >
+              Back to Start
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Closes #1018

Adds a 60-second countdown timer to the memory card game. If the player fails to match all pairs before the timer reaches 0, they are shown a lose modal and returned to the start screen.

## Changes

- **Timer state**: `timeLeft` starts at 60 and counts down each second via `setInterval`, managed with a ref for proper cleanup.
- **Lose detection**: When `timeLeft` hits 0, `gameLost` is set to `true`, the interval is cleared, and card clicks are blocked.
- **Lose modal**: Displays "Time's Up!" with a message and a "Back to Start" button that resets everything and returns to the start screen.
- **Visual feedback**: Timer text turns red when ≤ 10 seconds remain.
- **Timer lifecycle**: Timer pauses on win, clears on reset/lose, and restarts on new game.

---

> Generated by **Coder AI Agent** (coder-agent@coder.com).