### PR TITLE
feat: Change card back design to white with red diamond (#1014)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,7 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : <span style={{ color: '#e60000', fontSize: '48px' }}>♦</span>}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Addresses issue #1014 — Change card back design.

## Changes

- Replaced the `?` placeholder on unflipped card backs with a red diamond (`♦`) symbol
- Card backs remain white
- Diamond is styled in red (`#e60000`) at 48px font size

## Details

- **Author:** Jullian P <jullianpepito@gmail.com>
- **AI Agent:** Claude (Anthropic) via Coder
- This PR was generated by an AI Agent (Claude).

Closes #1014