### PR TITLE
feat: Add 60-second countdown timer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+
+const TIMER_SECONDS = 60;
 
 const MemoryGame = () => {
   const [cards, setCards] = useState([]);
@@ -7,6 +9,9 @@ const MemoryGame = () => {
   const [moves, setMoves] = useState(0);
   const [gameStarted, setGameStarted] = useState(false);
   const [gameWon, setGameWon] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(TIMER_SECONDS);
+  const [gameLost, setGameLost] = useState(false);
+  const timerRef = useRef(null);
 
   // Card emojis for the game
   const cardSymbols = ['🚀', '🛸', '⭐', '🌙', '🪐', '☄️', '🌟', '🌌'];
@@ -28,11 +33,74 @@ const MemoryGame = () => {
     setMoves(0);
     setGameStarted(true);
     setGameWon(false);
+    setGameLost(false);
+    setTimeLeft(TIMER_SECONDS);
+
+    // Clear any existing timer
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+    }
+
+    // Start countdown timer
+    timerRef.current = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(timerRef.current);
+          timerRef.current = null;
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  // Detect loss when timer reaches 0
+  useEffect(() => {
+    if (gameStarted && !gameWon && timeLeft === 0) {
+      setGameLost(true);
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    }
+  }, [timeLeft, gameStarted, gameWon]);
+
+  // Stop timer when game is won
+  useEffect(() => {
+    if (gameWon && timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, [gameWon]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+      }
+    };
+  }, []);
+
+  // Return to start screen
+  const returnToStart = () => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    setGameStarted(false);
+    setGameLost(false);
+    setGameWon(false);
+    setCards([]);
+    setFlippedIndices([]);
+    setMatchedPairs([]);
+    setMoves(0);
+    setTimeLeft(TIMER_SECONDS);
   };
 
   // Handle card click
   const handleCardClick = (index) => {
-    if (!gameStarted || gameWon) return;
+    if (!gameStarted || gameWon || gameLost) return;
     if (flippedIndices.length === 2) return;
     if (flippedIndices.includes(index)) return;
     if (matchedPairs.includes(cards[index].symbol)) return;
@@ -123,6 +191,12 @@ const MemoryGame = () => {
         }}>
           <div>Moves: {moves}</div>
           <div>Matches: {matchedPairs.length}/{cardSymbols.length}</div>
+          <div style={{
+            color: timeLeft <= 10 ? '#ff6b6b' : 'white',
+            animation: timeLeft <= 10 ? 'pulse 1s infinite' : 'none'
+          }}>
+            Time: {timeLeft}s
+          </div>
         </div>
       )}
 
@@ -234,6 +308,100 @@ const MemoryGame = () => {
         </button>
       )}
 
+      {/* Lose Modal */}
+      {gameLost && (
+        <div style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          background: 'rgba(0,0,0,0.8)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 1000
+        }}>
+          <div style={{
+            background: 'white',
+            padding: '40px',
+            borderRadius: '20px',
+            textAlign: 'center',
+            boxShadow: '0 10px 40px rgba(0,0,0,0.3)'
+          }}>
+            <h2 style={{
+              fontSize: '48px',
+              margin: '0 0 20px 0',
+              color: '#e74c3c'
+            }}>
+              ⏰ Time's Up! ⏰
+            </h2>
+            <p style={{
+              fontSize: '24px',
+              margin: '0 0 10px 0',
+              color: '#333'
+            }}>
+              You ran out of time!
+            </p>
+            <p style={{
+              fontSize: '18px',
+              margin: '0 0 30px 0',
+              color: '#666'
+            }}>
+              Matched {matchedPairs.length}/{cardSymbols.length} pairs in {moves} moves
+            </p>
+            <div style={{ display: 'flex', gap: '15px', justifyContent: 'center' }}>
+              <button
+                onClick={initializeGame}
+                style={{
+                  padding: '15px 40px',
+                  fontSize: '20px',
+                  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                  border: 'none',
+                  borderRadius: '50px',
+                  cursor: 'pointer',
+                  fontWeight: 'bold',
+                  color: 'white',
+                  boxShadow: '0 4px 15px rgba(0,0,0,0.2)',
+                  transition: 'all 0.3s ease'
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.transform = 'scale(1.05)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.transform = 'scale(1)';
+                }}
+              >
+                Try Again
+              </button>
+              <button
+                onClick={returnToStart}
+                style={{
+                  padding: '15px 40px',
+                  fontSize: '20px',
+                  background: 'white',
+                  border: '2px solid #667eea',
+                  borderRadius: '50px',
+                  cursor: 'pointer',
+                  fontWeight: 'bold',
+                  color: '#667eea',
+                  boxShadow: '0 4px 15px rgba(0,0,0,0.2)',
+                  transition: 'all 0.3s ease'
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.transform = 'scale(1.05)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.transform = 'scale(1)';
+                }}
+              >
+                Main Menu
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Win Modal */}
       {gameWon && (
         <div style={{
@@ -268,6 +436,13 @@ const MemoryGame = () => {
               color: '#333'
             }}>
               Completed in {moves} moves!
+            </p>
+            <p style={{
+              fontSize: '18px',
+              margin: '0 0 30px 0',
+              color: '#666'
+            }}>
+              Time remaining: {timeLeft}s
             </p>
             <button
               onClick={initializeGame}

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,11 @@ body {
   min-height: 100vh;
 }
 
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.7; transform: scale(1.1); }
+}
+
 h1 {
   font-size: 3.2em;
   line-height: 1.1;


### PR DESCRIPTION
## Summary

Adds a 60-second countdown timer to the memory card game per #1018.

## Changes

- **Countdown timer** starts at 60 seconds when the game begins, displayed in the stats bar
- **Visual urgency**: Timer turns red and pulses when ≤10 seconds remain
- **Lose detection**: When the timer hits 0, a "Time's Up!" modal appears showing progress (pairs matched, moves taken)
- **Lose modal actions**: "Try Again" restarts immediately; "Main Menu" returns to the start screen
- **Win modal enhanced**: Now shows remaining time alongside move count
- **Card interaction blocked** when time expires (no clicks after game over)
- **Timer cleanup**: Properly clears intervals on win, loss, reset, and component unmount

## Testing

1. Click "Start Game" — timer counts down from 60
2. Let it expire — lose modal appears, cards are unclickable
3. Click "Try Again" — new game starts with fresh timer
4. Click "Main Menu" — returns to start screen
5. Win the game — timer stops, remaining time shown in win modal

Closes #1018