### PR TITLE
feat: Change card back design to white with red diamond (#1014)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,22 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : (
+                <svg
+                  width="50"
+                  height="50"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                  style={{ filter: 'drop-shadow(0 2px 3px rgba(0,0,0,0.15))' }}
+                >
+                  <polygon
+                    points="50,5 95,50 50,95 5,50"
+                    fill="#e53e3e"
+                    stroke="#c53030"
+                    strokeWidth="2"
+                  />
+                </svg>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Addresses issue #1014 — Change card back design.

### Changes

- Replaced the `?` text placeholder on card backs with an inline SVG red diamond shape
- Card backs remain white as specified in the issue
- The diamond is rendered as an SVG polygon with a red fill (`#e53e3e`) and darker red stroke (`#c53030`)
- Added a subtle drop shadow for visual polish

### Details

- **Author:** Jullian P (jullianpepito@gmail.com)
- **AI Agent:** Claude (Coder Agent)
- This pull request was generated by an AI Agent (Claude) via the Coder platform.

Closes #1014