### PR TITLE
feat: Change card back design to white with red diamond

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,9 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : (
+                <span style={{ color: '#e53e3e', fontSize: '48px' }}>♦</span>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Resolves #1014 — Changes the card back design by replacing the `?` placeholder with a **red diamond (♦)** symbol. The card back remains white with a centered red diamond, as specified in the issue.

## Changes

- **`src/App.jsx`**: Replaced the `'?'` text on unflipped cards with a `<span>` rendering a red ♦ character (`#e53e3e`) at 48px.

## Details

- **GIT_AUTHOR_NAME**: Jullian P
- **GIT_AUTHOR_EMAIL**: jullianpepito@gmail.com
- **AI Agent**: This PR was authored by **Claude** (AI coding agent via Coder).