### PR TITLE
feat: Change card back design to red diamond

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,11 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : (
+                <svg width="40" height="50" viewBox="0 0 40 50" xmlns="http://www.w3.org/2000/svg">
+                  <polygon points="20,0 40,25 20,50 0,25" fill="#e74c3c" />
+                </svg>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Addresses issue #1014 — Change the card back design.

## Changes

- Replaced the `?` text placeholder on unflipped card backs with an inline SVG red diamond shape
- Card backs remain white with a centered red diamond polygon
- No changes to flipped card appearance or game logic

## Before
White card backs showing a `?` character.

## After
White card backs displaying a red diamond shape (SVG polygon).

Closes #1014