### PR TITLE
feat: Change card back design to white with red diamond

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,9 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : (
+                <span style={{ color: '#e53e3e', fontSize: '48px' }}>♦</span>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Addresses #1014 — Changes the card back design to display a **red diamond (♦)** on a white background, replacing the previous `?` placeholder.

## Changes

- Replaced the `?` text on unflipped card backs with a red diamond (`♦`) character
- Diamond is styled in red (`#e53e3e`) at 48px font size
- Card back background remains white (unchanged)

## Author Info

- **GIT_AUTHOR_NAME:** Jullian P
- **AI Agent:** Claude (via Coder AI agent)

> This pull request was authored by an AI Agent (Claude) through the Coder platform.