### PR TITLE
Change card back design: add red diamond

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,21 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : (
+                <svg
+                  width="50"
+                  height="60"
+                  viewBox="0 0 50 60"
+                  style={{ display: 'block' }}
+                >
+                  <polygon
+                    points="25,5 45,30 25,55 5,30"
+                    fill="#e53e3e"
+                    stroke="#c53030"
+                    strokeWidth="1.5"
+                  />
+                </svg>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Resolves #1014

Changes the card back design by replacing the `?` placeholder with a **red diamond** SVG on a white background.

### Changes
- Replaced the text `?` on card backs with an inline SVG red diamond shape
- Card backs remain white as specified in the issue
- Red diamond is centered on the card using a `<polygon>` element with a rich red fill (`#e53e3e`) and slightly darker stroke (`#c53030`)

### Author
- **Name:** Jullian P
- **Email:** jullianpepito@gmail.com
- **AI Agent:** Claude (via Coder)

> This pull request was created by an AI Agent (Claude) through Coder.