### PR TITLE
Change card back design: add red diamond (#1014)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,11 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : (
+                <svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+                  <polygon points="20,2 38,20 20,38 2,20" fill="#e53e3e" />
+                </svg>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

- Replaces the `?` text on card backs with a red diamond SVG shape
- Card back remains white with a centered red diamond polygon
- Closes #1014

## Details

- **GIT_AUTHOR_NAME:** coder-contrib-bot
- **GIT_AUTHOR_EMAIL:** coder-contrib-bot@users.noreply.github.com
- **AI Agent:** Claude Code (claude-opus-4-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>