### PR TITLE
feat: Change card back design to red diamond (#1014)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,9 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : (
+                <span style={{ color: '#e31837', fontSize: '48px' }}>♦</span>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Resolves #1014 — Changes the card back design to display a red diamond (♦) on a white background.

## Changes

- Replaced the `?` placeholder text on face-down cards with a red diamond symbol (♦)
- Card backs remain white with the diamond centered
- Diamond is styled in red (`#e31837`) at 48px font size

## Author Info

- **Author**: Jullian P <jullianpepito@gmail.com>
- **AI Agent**: Claude (Coder Agent)

This PR was created by an AI Agent (Claude) via Coder.