### PR TITLE
fix(#1018): Add 60-second countdown timer with lose detection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 const MemoryGame = () => {
   const [cards, setCards] = useState([]);
@@ -7,6 +7,9 @@ const MemoryGame = () => {
   const [moves, setMoves] = useState(0);
   const [gameStarted, setGameStarted] = useState(false);
   const [gameWon, setGameWon] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(60);
+  const [gameLost, setGameLost] = useState(false);
+  const timerRef = useRef(null);
 
   // Card emojis for the game
   const cardSymbols = ['🚀', '🛸', '⭐', '🌙', '🪐', '☄️', '🌟', '🌌'];
@@ -28,11 +31,47 @@ const MemoryGame = () => {
     setMoves(0);
     setGameStarted(true);
     setGameWon(false);
+    setGameLost(false);
+    setTimeLeft(60);
   };
+
+  // Return to start screen
+  const returnToStart = () => {
+    setGameStarted(false);
+    setGameWon(false);
+    setGameLost(false);
+    setTimeLeft(60);
+    setCards([]);
+    setFlippedIndices([]);
+    setMatchedPairs([]);
+    setMoves(0);
+  };
+
+  // Countdown timer
+  useEffect(() => {
+    if (gameStarted && !gameWon && !gameLost) {
+      timerRef.current = setInterval(() => {
+        setTimeLeft((prev) => {
+          if (prev <= 1) {
+            clearInterval(timerRef.current);
+            setGameLost(true);
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+      }
+    };
+  }, [gameStarted, gameWon, gameLost]);
 
   // Handle card click
   const handleCardClick = (index) => {
-    if (!gameStarted || gameWon) return;
+    if (!gameStarted || gameWon || gameLost) return;
     if (flippedIndices.length === 2) return;
     if (flippedIndices.includes(index)) return;
     if (matchedPairs.includes(cards[index].symbol)) return;
@@ -123,6 +162,9 @@ const MemoryGame = () => {
         }}>
           <div>Moves: {moves}</div>
           <div>Matches: {matchedPairs.length}/{cardSymbols.length}</div>
+          <div style={{ color: timeLeft <= 10 ? '#ff6b6b' : 'white' }}>
+            Time: {timeLeft}s
+          </div>
         </div>
       )}
 
@@ -291,6 +333,68 @@ const MemoryGame = () => {
               }}
             >
               Play Again
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Lose Modal - Time's Up */}
+      {gameLost && (
+        <div style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          background: 'rgba(0,0,0,0.8)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 1000
+        }}>
+          <div style={{
+            background: 'white',
+            padding: '40px',
+            borderRadius: '20px',
+            textAlign: 'center',
+            boxShadow: '0 10px 40px rgba(0,0,0,0.3)'
+          }}>
+            <h2 style={{
+              fontSize: '48px',
+              margin: '0 0 20px 0',
+              color: '#e74c3c'
+            }}>
+              ⏰ Time&apos;s Up! ⏰
+            </h2>
+            <p style={{
+              fontSize: '24px',
+              margin: '0 0 30px 0',
+              color: '#333'
+            }}>
+              You did not complete the game in time!
+            </p>
+            <button
+              onClick={returnToStart}
+              style={{
+                padding: '15px 40px',
+                fontSize: '20px',
+                background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                border: 'none',
+                borderRadius: '50px',
+                cursor: 'pointer',
+                fontWeight: 'bold',
+                color: 'white',
+                boxShadow: '0 4px 15px rgba(0,0,0,0.2)',
+                transition: 'all 0.3s ease'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.transform = 'scale(1.05)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.transform = 'scale(1)';
+              }}
+            >
+              Back to Start
             </button>
           </div>
         </div>


### PR DESCRIPTION
Closes #1018

## Summary

Adds a 60-second countdown timer to the memory card game. The timer starts when the game begins and counts down each second. If the timer reaches 0 before all pairs are matched, a lose modal is displayed notifying the user they did not complete the game in time, and a button returns them to the start screen. The timer also turns red when 10 seconds or fewer remain.

## Files Modified

- `src/App.jsx` — Added `timeLeft` and `gameLost` state, a `useEffect` countdown interval, timer display in the stats bar, and a "Time's Up" lose modal.

## AI Agent Disclosure

This PR was authored by an AI agent (Claude) on behalf of the repository.
- GIT_AUTHOR_NAME: $GIT_AUTHOR_NAME
- GIT_AUTHOR_EMAIL: $GIT_AUTHOR_EMAIL

<details>
<summary>Verification output</summary>

```
$ npm run lint
> memory-game-ai-demo@0.0.0 lint
> eslint .
(no errors)

$ npm run build
> memory-game-ai-demo@0.0.0 build
> vite build
✓ 15 modules transformed.
dist/index.html                   0.46 kB │ gzip:  0.30 kB
dist/assets/index-4eoCdr-l.css    1.08 kB │ gzip:  0.53 kB
dist/assets/index-BJBNJC0Z.js   197.07 kB │ gzip: 61.92 kB
✓ built in 105ms
```

</details>