### PR TITLE
fix(#1014): Add red diamond to card back design

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,7 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : <span style={{ color: 'red' }}>♦</span>}
             </div>
           ))}
         </div>


### PR DESCRIPTION
Closes #1014

## Summary

Changes the card back design to display a red diamond (♦) instead of the previous "?" character. The card back remains white as specified in the issue. This is a minimal one-line change in `src/App.jsx`.

## Files Modified

- `src/App.jsx` — replaced the `?` card back text with a red diamond (`<span style={{ color: "red" }}>♦</span>`)

<details>
<summary>Command output</summary>

```
$ npm run lint

> memory-game-ai-demo@0.0.0 lint
> eslint .

(no errors)

$ npm run build

> memory-game-ai-demo@0.0.0 build
> vite build

rolldown-vite v7.1.14 building for production...
✓ 15 modules transformed.
dist/index.html                   0.46 kB │ gzip:  0.29 kB
dist/assets/index-4eoCdr-l.css    1.08 kB │ gzip:  0.53 kB
dist/assets/index-DQ2hSVnb.js  195.71 kB │ gzip: 61.71 kB
✓ built in 107ms
```

</details>

---
*This PR was authored by an AI agent (Coder agent) on behalf of @daveahr2172.*