### PR TITLE
Add red diamond to card backs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,7 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : <span style={{ color: '#e63946', fontSize: '52px' }}>♦</span>}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Replaced the "?" placeholder on unflipped cards with a red diamond (♦) symbol
- The diamond is styled in red (#e63946) at 52px font size for visual appeal

## Details
- **GIT_AUTHOR_NAME:** default
- **GIT_AUTHOR_EMAIL:** michael.patterson@coder.com
- **AI Agent:** Claude Code (Claude Opus 4.5)

## Test plan
- [ ] Start the game and verify unflipped cards show a red ♦ instead of "?"
- [ ] Verify flipping cards still reveals the emoji symbol correctly
- [ ] Verify matched cards still fade as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)