### PR TITLE
feat: add red diamond to card backs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -153,6 +153,7 @@ const MemoryGame = () => {
                 alignItems: 'center',
                 justifyContent: 'center',
                 fontSize: '48px',
+                color: isCardVisible(index, card.symbol) ? 'inherit' : '#e11d48',
                 cursor: matchedPairs.includes(card.symbol) ? 'default' : 'pointer',
                 transform: isCardVisible(index, card.symbol) ? 'scale(1)' : 'scale(1)',
                 transition: 'all 0.3s ease',
@@ -169,7 +170,7 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : '♦'}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Replaced the `?` placeholder on card backs with a red diamond (`♦`) symbol
- Added red color (`#e11d48`) styling for the diamond when the card is face-down
- Cards retain their normal appearance when flipped face-up

## Details
- **GIT_AUTHOR_NAME:** default
- **GIT_AUTHOR_EMAIL:** michael.patterson@coder.com
- **AI Agent:** Claude Code (Claude Opus 4.5)

This change was generated by an AI Agent (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)