### PR TITLE
fix(#1014): Change card back design to red diamond

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,7 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : <span style={{ color: 'red' }}>♦</span>}
             </div>
           ))}
         </div>


### PR DESCRIPTION
Closes #1014

## Summary

Replaces the `?` character on card backs with a red diamond (`♦`) symbol rendered in red (`color: red`). The card back background remains white as requested. This is a single-line change in `src/App.jsx`.

## Files Modified

- `src/App.jsx` — Changed the card-back content from `'?'` to `<span style={{ color: "red" }}>♦</span>`

<details>
<summary>Lint output</summary>

```
> memory-game-ai-demo@0.0.0 lint
> eslint .

(no errors)
```

</details>

<details>
<summary>Build output</summary>

```
> memory-game-ai-demo@0.0.0 build
> vite build

rolldown-vite v7.1.14 building for production...
✓ 15 modules transformed.
dist/index.html                   0.46 kB │ gzip:  0.29 kB
dist/assets/index-4eoCdr-l.css    1.08 kB │ gzip:  0.53 kB
dist/assets/index-DQ2hSVnb.js   195.71 kB │ gzip: 61.71 kB
✓ built in 106ms
```

</details>
