### PR TITLE
Add red diamond to card back design

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -158,7 +158,8 @@ const MemoryGame = () => {
                 transition: 'all 0.3s ease',
                 boxShadow: '0 4px 8px rgba(0,0,0,0.2)',
                 userSelect: 'none',
-                opacity: matchedPairs.includes(card.symbol) ? 0.6 : 1
+                opacity: matchedPairs.includes(card.symbol) ? 0.6 : 1,
+                position: 'relative'
               }}
               onMouseEnter={(e) => {
                 if (!matchedPairs.includes(card.symbol) && !isCardVisible(index, card.symbol)) {
@@ -169,7 +170,25 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? (
+                card.symbol
+              ) : (
+                <>
+                  <span style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', fontSize: '48px' }}>?</span>
+                  <svg
+                    width="30"
+                    height="30"
+                    viewBox="0 0 30 30"
+                    style={{
+                      position: 'absolute',
+                      top: '5px',
+                      right: '5px'
+                    }}
+                  >
+                    <polygon points="15,0 30,15 15,30 0,15" fill="#FF0000" />
+                  </svg>
+                </>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Description
Resolves #1014

Add a red diamond design element to the card back. The cards remain white but now feature a red diamond in the top-right corner to enhance the visual design.

## Changes
- Added an SVG diamond element to unflipped card backs
- Positioned the red diamond at the top-right corner
- Maintained white background for card backs
- Used CSS positioning to layer the diamond with the question mark

## Visual Changes
- Unflipped cards now display a red diamond alongside the question mark
- The diamond is rendered as an SVG polygon for clean, scalable graphics
- Red diamond (#FF0000) provides clear visual contrast on white background