### PR TITLE
fix: replace card back '?' with red diamond

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,9 @@ const MemoryGame = () => {
                 e.currentTarget.style.transform = 'scale(1)';
               }}
             >
-              {isCardVisible(index, card.symbol) ? card.symbol : '?'}
+              {isCardVisible(index, card.symbol) ? card.symbol : (
+                <span style={{ color: '#e00', fontSize: '48px', lineHeight: 1 }}>♦</span>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
Resolves #1014

## Changes
- Replaced the `?` placeholder on face-down cards with a red ♦ diamond character
- Card back remains white; only the symbol changes to a red diamond (`color: #e00`)

No other styles or game logic were modified.